### PR TITLE
[systemd] Add unit-file

### DIFF
--- a/systemd/clsync@.service
+++ b/systemd/clsync@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=clsync (live file syncer)
+After=timers.target local-fs.target cryptsetup.target remote-fs.target network.target
+
+[Service]
+Type=exec
+EnvironmentFile=-/etc/clsync/env
+ExecStart=/usr/bin/clsync -K %i
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is a systemd unit-file for a generic case (without Debian-specifics).

See also with Debian-specifics in: https://github.com/clsync/clsync/commit/29e3aa86c064e95096d1a75b520a7a3e864e41f4

Usage:

```sh
cp systemd/'clsync@.service' /etc/systemd/system/
systemctl enable clsync@SomeConfig
mkdir -p /etc/clsync
cat > /etc/clsync/clsync.conf <<EOF
[SomeConfig]
mode = simple
watch-dir = /tmp
sync-handler = echo
EOF
systemctl start clsync@SomeConfig
systemctl status clsync@SomeConfig
```
