### PR TITLE
Debian packaging updates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -9,7 +9,13 @@ clsync (0.4.4-1) unstable; urgency=medium
   [Dmitrii Okunev]
   * Added systemd unit-file
 
- -- Andrew Savchenko <bircoph@gmail.com>  Sat, 25 Apr 2020 20:35:42 +0300
+  [ Barak A. Pearlmutter ]
+  * Depend on newer debhelper (>= 9.20160709) rather than dh-systemd.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+  * Update standards version to 4.5.0, no changes needed.
+
+ -- Barak A. Pearlmutter <bap@debian.org>  Fri, 08 May 2020 16:47:15 +0100
 
 clsync (0.4.3-1) unstable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -3,10 +3,10 @@ Section: admin
 Priority: optional
 Maintainer: Artyom A Anikeev <anikeev@ut.mephi.ru>
 Uploaders: Barak A. Pearlmutter <bap@debian.org>, Dmitry Yu Okunev <dyokunev@ut.mephi.ru>
-Build-Depends: debhelper-compat (= 12), dh-systemd,
+Build-Depends: debhelper-compat (= 12),
 	       libglib2.0-dev (>= 2.0.0),
 	       libcgroup-dev, libcap-dev
-Standards-Version: 4.3.0
+Standards-Version: 4.5.0
 Homepage: http://ut.mephi.ru/oss
 Vcs-Git: https://salsa.debian.org/debian/clsync.git
 Vcs-Browser: https://salsa.debian.org/debian/clsync

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Build-Depends: debhelper-compat (= 13),
 	       libglib2.0-dev (>= 2.0.0),
 	       libcgroup-dev, libcap-dev
 Standards-Version: 4.5.0
+Rules-Requires-Root: no
 Homepage: http://ut.mephi.ru/oss
 Vcs-Git: https://salsa.debian.org/debian/clsync.git
 Vcs-Browser: https://salsa.debian.org/debian/clsync

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Artyom A Anikeev <anikeev@ut.mephi.ru>
 Uploaders: Barak A. Pearlmutter <bap@debian.org>, Dmitry Yu Okunev <dyokunev@ut.mephi.ru>
-Build-Depends: debhelper-compat (= 12),
+Build-Depends: debhelper-compat (= 13),
 	       libglib2.0-dev (>= 2.0.0),
 	       libcgroup-dev, libcap-dev
 Standards-Version: 4.5.0

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/clsync/clsync/issues
+Bug-Submit: https://github.com/clsync/clsync/issues/new
+Repository: https://github.com/clsync/clsync.git
+Repository-Browse: https://github.com/clsync/clsync


### PR DESCRIPTION
Clone of https://github.com/clsync/clsync/pull/171 , but to branch `debian`.